### PR TITLE
fix bug in sample and yarn parameter; add yarn config and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	python -m unittest tests/test_*.py
+
+PHONY: test

--- a/aria/model/dynamic_yarn.py
+++ b/aria/model/dynamic_yarn.py
@@ -37,10 +37,10 @@ def linear_ramp_mask(min, max, dim):
     return ramp_func
 
 
-def get_mscale(scale=1):
+def get_mscale(scale=1, coeff=0.1):
     if scale <= 1:
         return 1.0
-    return 0.1 * math.log(scale) + 1.0
+    return coeff * math.log(scale) + 1.0
 
 
 class DynamicYaRNScaledRotaryEmbedding(torch.nn.Module):
@@ -52,6 +52,7 @@ class DynamicYaRNScaledRotaryEmbedding(torch.nn.Module):
         original_max_position_embeddings=2048,
         extrapolation_factor=1,
         attn_factor=1,
+        mscale_coeff=0.1,
         beta_fast=32,
         beta_slow=1,
         finetuned=False,
@@ -65,6 +66,7 @@ class DynamicYaRNScaledRotaryEmbedding(torch.nn.Module):
         self.original_max_position_embeddings = original_max_position_embeddings
         self.extrapolation_factor = extrapolation_factor
         self.attn_factor = attn_factor
+        self.mscale_coeff = mscale_coeff
         self.beta_fast = beta_fast
         self.beta_slow = beta_slow
 
@@ -159,5 +161,5 @@ class DynamicYaRNScaledRotaryEmbedding(torch.nn.Module):
 
         self.register_buffer("inv_freq", inv_freq)
         self.mscale = float(
-            get_mscale(scale) * self.attn_factor
+            get_mscale(scale, self.mscale_coeff) * self.attn_factor
         )  # Get n-d magnitude scaling corrected for interpolation

--- a/config/models/large_yarn.json
+++ b/config/models/large_yarn.json
@@ -1,0 +1,10 @@
+{
+    "d_model": 768,
+    "n_heads": 12,
+    "n_layers": 64,
+    "ff_mult": 4,
+    "drop_p": 0.1,
+    "max_seq_len": 4096,
+    "grad_checkpoint": false,
+    "yarn_config": {}
+}

--- a/config/models/test_yarn.json
+++ b/config/models/test_yarn.json
@@ -1,0 +1,15 @@
+{
+    "d_model": 128,
+    "n_heads": 4,
+    "n_layers": 4,
+    "ff_mult": 4,
+    "drop_p": 0.1,
+    "max_seq_len": 256,
+    "grad_checkpoint": false,
+    "yarn_config": {
+        "scale": 1.0,
+        "mscale_coeff": 0.07,
+        "beta_fast": 32,
+        "beta_slow": 1
+    }
+}

--- a/config/models/xlarge_yarn.json
+++ b/config/models/xlarge_yarn.json
@@ -1,0 +1,10 @@
+{
+    "d_model": 768,
+    "n_heads": 12,
+    "n_layers": 96,
+    "ff_mult": 4,
+    "drop_p": 0.1,
+    "max_seq_len": 4096,
+    "grad_checkpoint": false,
+    "yarn_config": {}
+}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,32 @@
+import logging
+import unittest
+
+from aria.model import ModelConfig, TransformerLM
+from aria.config import load_model_config
+from aria.model.model import YaRNConfig
+from aria.tokenizer import TokenizerLazy
+
+
+class TestModel(unittest.TestCase):
+    def test_yarn_config(self):
+        tokenizer = TokenizerLazy(return_tensors=True)
+        model_config = ModelConfig(**load_model_config("test"))
+        model_config.set_vocab_size(tokenizer.vocab_size)
+        model = TransformerLM(model_config)
+        assert model.model.model_config.yarn_config is None
+        model_config = ModelConfig(**load_model_config("test_yarn"))
+        model_config.set_vocab_size(tokenizer.vocab_size)
+        model = TransformerLM(model_config)
+        assert isinstance(model.model.model_config.yarn_config, YaRNConfig)
+        max_len = model.model.encode_layers[0].rotary_emb.max_position_embeddings
+        org_max_len = model.model.encode_layers[0].rotary_emb.original_max_position_embeddings
+        assert max_len == org_max_len
+        assert model.model.encode_layers[0].rotary_emb.mscale_coeff == 0.07
+        assert model.model.encode_layers[0].rotary_emb.beta_fast == 32.0
+        assert model.model.encode_layers[0].rotary_emb.beta_slow == 1.0
+        assert model.model.encode_layers[0].rotary_emb.base == 10000.0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
- [x] Some bug fixes
- [x] Now ModelConfig has an optional `yarn_config`. The model uses yarn if this is not None. Nothing should break for the original json config. And to add a yarn_config we only need to add a nested dict into the json file (see the new `test_yarn.json` in config folder). Also wrote a unit test to make sure the config works.